### PR TITLE
chore(frontend): simplify — DRY, dead-field removal, memo, bug fixes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   type FoodItemResponse,
   type FoodItemRequest,
-  type SortOptions,
   type UserLocationResponse,
   type UserTypeResponse,
   type ItemDefaultsResponse,
@@ -28,6 +27,7 @@ import NavBar from "./components/NavBar";
 import {
   responseToFoodItemRequest,
   formDataToFoodItemRequest,
+  toggleInSet,
 } from "./utility/utils";
 
 import "./App.css";
@@ -46,7 +46,6 @@ function App() {
   const [modalState, setModalState] = useState<null | FoodItemResponse | "add">(
     null,
   );
-  const [sortBy, setSortBy] = useState<SortOptions>("name");
   const [isLogin, setIsLogin] = useState(true);
   const [userTypes, setUserTypes] = useState<UserTypeResponse[]>([]);
   const [userLocations, setUserLocations] = useState<UserLocationResponse[]>(
@@ -81,8 +80,6 @@ function App() {
     }
     fetchItems();
   }, [authToken]);
-
-  const authIsOpen = authToken === null;
 
   async function handleDeleteFoodItem(item: FoodItemResponse) {
     try {
@@ -119,11 +116,12 @@ function App() {
   async function handleLogout() {
     if (!authToken) return;
     try {
-      logoutUser(authToken, setToken);
-      setToken(null);
-      localStorage.clear();
+      await logoutUser(authToken, setToken);
     } catch (err) {
       console.log(err);
+    } finally {
+      setToken(null);
+      localStorage.clear();
     }
   }
 
@@ -148,11 +146,7 @@ function App() {
       setTypeFilter(new Set());
       return;
     }
-
-    const filterSet = typeFilter.has(type)
-      ? new Set([...typeFilter].filter((filter) => filter != type))
-      : new Set([...typeFilter, type]);
-    setTypeFilter(filterSet);
+    setTypeFilter((prev) => toggleInSet(prev, type));
   }
   async function handleAddType(name: string) {
     if (!authToken) return;
@@ -166,7 +160,7 @@ function App() {
     const usedTypes = foodList.map((item) => item.foodType);
     if (usedTypes.includes(name.toUpperCase())) {
       throw new Error(
-        `Food items with location ${name} exist. Delete items before deleting location.`,
+        `Food items with type ${name} exist. Delete items before deleting type.`,
       );
     }
     await deleteUserTypes(id, authToken, setToken);
@@ -200,22 +194,7 @@ function App() {
       setLocationFilter(new Set());
       return;
     }
-
-    const filterSet = locationFilter.has(location)
-      ? new Set([...locationFilter].filter((filter) => filter != location))
-      : new Set([...locationFilter, location]);
-    setLocationFilter(filterSet);
-  }
-
-  function sortCards(a: FoodItemResponse, b: FoodItemResponse): number {
-    switch (sortBy) {
-      case "location":
-        return a.location.localeCompare(b.location);
-      case "name":
-        return a.name.localeCompare(b.name);
-      case "type":
-        return a.foodType.localeCompare(b.foodType);
-    }
+    setLocationFilter((prev) => toggleInSet(prev, location));
   }
 
   function closeModals() {
@@ -246,12 +225,18 @@ function App() {
       ? handleAddedItem
       : (data: FormData) => handleEditItem(data, modalState.id);
 
+  const locationNames = useMemo(
+    () => userLocations.map((l) => l.name),
+    [userLocations],
+  );
+  const typeNames = useMemo(() => userTypes.map((t) => t.name), [userTypes]);
+
   const visibleItems = foodList
     .filter(
       (item) => locationFilter.size === 0 || locationFilter.has(item.location),
     )
     .filter((item) => typeFilter.size === 0 || typeFilter.has(item.foodType))
-    .sort(sortCards);
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   const grouped = groupItems(visibleItems);
 
@@ -275,15 +260,15 @@ function App() {
       )}
       {modalState && (
         <ItemModal
-          userLocations={userLocations.map((location) => location.name)}
-          userTypes={userTypes.map((type) => type.name)}
+          userLocations={locationNames}
+          userTypes={typeNames}
           initialValue={initialForm}
           itemDefaults={itemDefaults}
           setIsOpen={setModalState}
           onSubmit={modalSubmitHandler}
         ></ItemModal>
       )}
-      {authIsOpen && (
+      {authToken === null && (
         <AuthenticationModal
           mode={isLogin}
           setMode={setIsLogin}
@@ -302,13 +287,12 @@ function App() {
         </div>
       )}
       <FilterBar
-        userLocations={userLocations.map((location) => location.name)}
-        userTypes={userTypes.map((type) => type.name)}
+        userLocations={locationNames}
+        userTypes={typeNames}
         locationFilter={locationFilter}
         typeFilter={typeFilter}
         setTypeFilter={typeFilterHandler}
         setLocationFilter={locationFilterHandler}
-        setSortType={setSortBy}
         setGroupBy={setGroupBy}
       ></FilterBar>
       {foodLoading ? (

--- a/frontend/src/api/fetchFood.ts
+++ b/frontend/src/api/fetchFood.ts
@@ -14,6 +14,8 @@ async function throwIfNotOk(response: Response): Promise<void> {
   if (response.ok) return;
   const errorBody = await response.json().catch(() => ({}));
   throw new Error(errorBody.detail ?? "Something went wrong");
+}
+
 let refreshInFlight: Promise<string> | null = null;
 
 async function refreshAccessToken(

--- a/frontend/src/api/fetchFood.ts
+++ b/frontend/src/api/fetchFood.ts
@@ -10,6 +10,12 @@ import {
 
 const API_URI = import.meta.env.VITE_API_URL;
 
+async function throwIfNotOk(response: Response): Promise<void> {
+  if (response.ok) return;
+  const errorBody = await response.json().catch(() => ({}));
+  throw new Error(errorBody.detail ?? "Something went wrong");
+}
+
 export async function apiFetch(
   url: string,
   options: RequestInit,
@@ -64,10 +70,7 @@ export async function getAllFoodItems(
     setToken,
   );
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 
   const data = await response.json();
   return data;
@@ -90,10 +93,7 @@ export async function createNewFoodItem(
     setToken,
   );
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
   const data = await response.json();
   return data;
 }
@@ -116,10 +116,7 @@ export async function updateFoodItem(
     setToken,
   );
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 
   const data = await response.json();
   return data;
@@ -137,10 +134,7 @@ export async function deleteFoodItem(
     token,
     setToken,
   );
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 }
 
 export async function getTokenLogin(
@@ -154,10 +148,7 @@ export async function getTokenLogin(
     credentials: "include",
   });
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
   const result = await response.json();
   return result.accessToken as Token;
 }
@@ -171,10 +162,7 @@ export async function createNewUser(
     body: JSON.stringify({ username, password }),
   });
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 }
 export async function logoutUser(
   token: Token,
@@ -189,10 +177,7 @@ export async function logoutUser(
     setToken,
   );
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 }
 
 export async function getUserLocations(
@@ -208,10 +193,7 @@ export async function getUserLocations(
     setToken,
   );
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 
   const data = await response.json();
   return data;
@@ -230,10 +212,7 @@ export async function getUserTypes(
     setToken,
   );
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 
   const data = await response.json();
   return data;
@@ -258,10 +237,7 @@ export async function addUserLocations(
     setToken,
   );
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 
   const data = await response.json();
   return data;
@@ -286,10 +262,7 @@ export async function addUserTypes(
     setToken,
   );
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 
   const data = await response.json();
   return data;
@@ -309,10 +282,7 @@ export async function deleteUserLocations(
     setToken,
   );
 
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 }
 
 export async function deleteUserTypes(
@@ -328,10 +298,7 @@ export async function deleteUserTypes(
     token,
     setToken,
   );
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
 }
 
 export async function getItemDefaults(
@@ -346,10 +313,7 @@ export async function getItemDefaults(
     token,
     setToken,
   );
-  if (!response.ok) {
-    const errorBody = await response.json();
-    throw new Error(errorBody.detail ?? "Something went wrong");
-  }
+  await throwIfNotOk(response);
   const data = await response.json();
   return data;
 }

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,4 +1,3 @@
-import { type SortOptions } from "../types/types";
 type GroupByOptions = "none" | "location" | "type";
 type FilterBarProps = {
   userLocations: string[];
@@ -7,8 +6,7 @@ type FilterBarProps = {
   typeFilter: Set<string>;
   setLocationFilter: (location: string | null) => void;
   setTypeFilter: (type: string | null) => void;
-  setSortType: (type: SortOptions) => void;
-  setGroupBy: (grouping: "none" | "location" | "type") => void;
+  setGroupBy: (grouping: GroupByOptions) => void;
 };
 
 export default function FilterBar({
@@ -18,7 +16,6 @@ export default function FilterBar({
   typeFilter,
   setLocationFilter,
   setTypeFilter,
-  // setSortType,
   setGroupBy,
 }: FilterBarProps) {
   return (
@@ -65,16 +62,6 @@ export default function FilterBar({
       </div>
 
       <div className="filterrow">
-        {/* <select
-          name="sortby"
-          onChange={(e) => setSortType(e.target.value as SortOptions)}
-        >
-          {SORT_TYPE.map((sort) => (
-            <option key={sort} value={sort}>
-              {sort}
-            </option>
-          ))}
-        </select> */}
         <select
           name="groupby"
           onChange={(e) => setGroupBy(e.target.value as GroupByOptions)}

--- a/frontend/src/components/FoodCard.tsx
+++ b/frontend/src/components/FoodCard.tsx
@@ -1,4 +1,5 @@
 import { type FoodItemResponse } from "../types/types";
+import { formatName } from "../utility/utils";
 type FoodCardProps = {
   item: FoodItemResponse;
   onDelete: (item: FoodItemResponse) => void;
@@ -33,15 +34,4 @@ export default function FoodCard({ item, onDelete, onEdit }: FoodCardProps) {
       </div>
     </div>
   );
-}
-
-function formatName(name: string) {
-  const words = name.toLowerCase().split(" ");
-  const formattedName = words.reduce(
-    (acc, curVal) =>
-      acc + (curVal.charAt(0).toUpperCase() + curVal.slice(1) + " "),
-    "",
-  );
-
-  return formattedName.trim();
 }

--- a/frontend/src/components/ItemModal.tsx
+++ b/frontend/src/components/ItemModal.tsx
@@ -5,6 +5,7 @@ import {
   type ItemDefaultsResponse,
   type Unit,
 } from "../types/types";
+import { todayISO } from "../utility/utils";
 type ItemModalProps = {
   initialValue: FoodItemRequest | null | "add";
   userLocations: string[];
@@ -34,10 +35,8 @@ export default function ItemModal({
           quantity: 0,
           unit: "COUNT",
           location: "FRIDGE",
-          expirationDate: new Date().toISOString().split("T")[0],
-          purchaseDate: new Date().toISOString().split("T")[0],
-          openedAt: new Date().toISOString().split("T")[0],
-          notes: "",
+          expirationDate: todayISO(),
+          purchaseDate: todayISO(),
         }
       : initialValue;
   const [itemName, setItemName] = useState(defaultValues.name);
@@ -46,9 +45,9 @@ export default function ItemModal({
   const [itemUnit, setItemUnit] = useState(defaultValues.unit);
   const [itemExpDate, setItemExpDate] = useState(defaultValues.expirationDate);
 
-  async function handleSubmit(event: React.SubmitEvent) {
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const formData = new FormData(event.currentTarget as HTMLFormElement);
+    const formData = new FormData(event.currentTarget);
     try {
       setIsLoading(true);
       setError(null);
@@ -84,6 +83,7 @@ export default function ItemModal({
       date.setDate(date.getDate() + defaults.expirationDays);
       setItemExpDate(date.toISOString().split("T")[0]);
     }
+
     setSuggestions([]);
   }
 

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -34,8 +34,7 @@ export type FoodItemRequest = {
   location: string;
   expirationDate: string;
   purchaseDate: string;
-  openedAt: string;
-  notes: string;
+  notes?: string;
 };
 export type FoodItemResponse = {
   id: number;
@@ -46,7 +45,6 @@ export type FoodItemResponse = {
   location: string;
   expirationDate: string;
   purchaseDate?: string;
-  openedAt?: string;
   notes?: string;
   consumed?: boolean;
   createdAt?: string;

--- a/frontend/src/utility/utils.ts
+++ b/frontend/src/utility/utils.ts
@@ -1,5 +1,25 @@
 import type { FoodItemRequest, FoodItemResponse, Unit } from "../types/types";
 
+export function todayISO() {
+  return new Date().toISOString().split("T")[0];
+}
+
+export function toggleInSet<T>(set: Set<T>, value: T): Set<T> {
+  const next = new Set(set);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  return next;
+}
+
+export function formatName(name: string) {
+  return name
+    .toLowerCase()
+    .split(" ")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ")
+    .trim();
+}
+
 export function responseToFoodItemRequest(item: FoodItemResponse) {
   const requestItem: FoodItemRequest = {
     name: item.name,
@@ -8,9 +28,7 @@ export function responseToFoodItemRequest(item: FoodItemResponse) {
     unit: item.unit,
     location: item.location,
     expirationDate: item.expirationDate,
-    purchaseDate: item.purchaseDate ?? new Date().toISOString().split("T")[0],
-    openedAt: item.openedAt ?? new Date().toISOString().split("T")[0],
-    notes: item.notes ?? "",
+    purchaseDate: item.purchaseDate ?? todayISO(),
   };
 
   return requestItem;
@@ -25,8 +43,6 @@ export function formDataToFoodItemRequest(data: FormData) {
     location: data.get("location") as string,
     expirationDate: data.get("expirationDate") as string,
     purchaseDate: data.get("purchaseDate") as string,
-    openedAt: data.get("openedAt") as string,
-    notes: data.get("notes") as string,
   };
   return requestItem;
 }


### PR DESCRIPTION
## Summary
- **DRY:** extracted `throwIfNotOk` helper in `fetchFood.ts` (replaces 14 copies of the 4-line error block) and `toggleInSet` / `todayISO` / `formatName` in `utility/utils.ts`.
- **Dead code:** removed `openedAt` field everywhere (request + response types, ItemModal form state) and the commented-out sort selector + unused `setSortType` plumbing through FilterBar → App.
- **Bug fixes:** `handleLogout` now awaits `logoutUser` so the server actually sees the call; `handleDeleteType` error message no longer says "location"; filter toggles use functional updaters on a cloned `Set`.
- **Perf:** memoized `locationNames` / `typeNames` projections in App — previously new array references every render defeated prop-equality bail-outs in FilterBar and ItemModal.

## Test plan
- [ ] Login + logout round trip — confirm `POST /auth/logout` fires before the token clears (previously raced).
- [ ] Create, edit, delete food items — form submits with correct payload (no phantom `openedAt` / `notes`).
- [ ] Toggle location and type filters, switch group-by — items regroup correctly.
- [ ] Settings modal: add then delete a type / location that's in use — error message names the right category.
- [ ] `npx tsc --noEmit` and `npm run build` pass from `frontend/`.