### PR TITLE
feat: QuickAddBar for one-tap item re-adds

### DIFF
--- a/docs/superpowers/plans/2026-04-16-quickaddbar.md
+++ b/docs/superpowers/plans/2026-04-16-quickaddbar.md
@@ -1,0 +1,688 @@
+# QuickAddBar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent "quick add" bar above the food grid so recurring items (one chip per stored `ItemDefault`) can be added in one tap with qty + expiry override, while first-time items keep the existing ItemModal path.
+
+**Architecture:** New `QuickAddBar` component rendered between `FilterBar` and the food grid in `App.tsx`. Each stored `ItemDefault` becomes a chip; tapping a chip expands it inline to reveal a qty stepper + expiry override form. Confirm POSTs via existing `createNewFoodItem`. A trailing `+ Add new` chip opens the existing `ItemModal`. Shelf-life (`ItemDefault.expirationDays`) is used to pre-fill the expiry picker — requires a bug fix in `App.tsx:handleAddedItem` which currently hardcodes `expirationDays: 0`.
+
+**Tech Stack:** React 19, TypeScript, Vite. Existing `fetchFood.ts` API. Existing CSS variables (`--tc`, `--sage`, `--cream`, `--ink`, `--sand`). No new dependencies. No test framework in repo — verification is type-check + Vite build + manual browser check.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-quickaddbar-design.md`
+
+---
+
+## File Structure
+
+| Path | Role | Action |
+| --- | --- | --- |
+| `frontend/src/components/QuickAddBar.tsx` | New component — chips, expansion state, inline form | Create |
+| `frontend/src/App.tsx` | Host; owns `itemDefaults`/`foodList`; adds `handleQuickAdd`; fixes `handleAddedItem` bug | Modify |
+| `frontend/src/App.css` | Styles for `.quickaddbar`, `.quickadd-chip`, expanded state | Modify |
+
+No backend changes. No new utility modules (component-local state is sufficient).
+
+**Interface contract between App and QuickAddBar** (defined in `QuickAddBar.tsx`, consumed by `App.tsx`):
+
+```ts
+export type QuickAddOverrides = {
+  quantity: number;
+  expirationDate: string; // ISO yyyy-mm-dd
+};
+
+type QuickAddBarProps = {
+  itemDefaults: ItemDefaultsResponse[];
+  onQuickAdd: (defaults: ItemDefaultsResponse, overrides: QuickAddOverrides) => Promise<void>;
+  onAddNew: () => void;
+};
+```
+
+---
+
+## Task 1: Fix `expirationDays` hardcode in `handleAddedItem`
+
+**Why first:** The entire feature depends on stored shelf-life being accurate. Currently every new `ItemDefault` gets `expirationDays: 0`, which would make every chip pre-fill the expiry picker to today. Fixing this standalone means Tasks 2–4 can be tested with real data without interleaving concerns.
+
+**Files:**
+- Modify: `frontend/src/App.tsx:95-114` (`handleAddedItem`)
+
+- [ ] **Step 1: Update `handleAddedItem` to compute `expirationDays` from the request's dates**
+
+Replace the current function body:
+
+```ts
+  async function handleAddedItem(data: FormData) {
+    if (!authToken) throw new Error("Not authenticated");
+
+    const request: FoodItemRequest = formDataToFoodItemRequest(data);
+    const response: FoodItemResponse = await createNewFoodItem(
+      request,
+      authToken,
+      setToken,
+    );
+    const expirationDays = Math.max(
+      0,
+      Math.round(
+        (new Date(request.expirationDate).getTime() -
+          new Date(request.purchaseDate).getTime()) /
+          (1000 * 60 * 60 * 24),
+      ),
+    );
+    const defaults: ItemDefaultsResponse = {
+      name: request.name.toUpperCase(),
+      foodType: request.foodType.toUpperCase(),
+      unit: request.unit.toUpperCase(),
+      location: request.location.toUpperCase(),
+      expirationDays,
+    };
+    setItemDefaults((prev) => [...prev, defaults]);
+    setFoodList((prev) => [...prev, response]);
+    setModalState(null);
+  }
+```
+
+- [ ] **Step 2: Verify type-check**
+
+Run from `F:\Claude\projects\kitchen\frontend`:
+```
+npx tsc --noEmit
+```
+Expected: exit 0, no output.
+
+- [ ] **Step 3: Verify Vite build**
+
+Run from the same directory:
+```
+npm run build
+```
+Expected: exit 0, "✓ built in …" at the end.
+
+- [ ] **Step 4: Manual smoke test**
+
+Boot the app. Log in. Open the full ItemModal via the NavBar add button. Create a new item named `TEST-SHELFLIFE` with purchase date today and expiration date 7 days from today. Submit. Verify in React DevTools (or by logging) that the newly-appended `itemDefaults` entry has `expirationDays: 7`, not 0.
+
+- [ ] **Step 5: Commit**
+
+```
+git add frontend/src/App.tsx
+git commit -m "fix(app): compute expirationDays from request dates"
+```
+
+---
+
+## Task 2: Scaffold `QuickAddBar` component and wire `onAddNew`
+
+**Why second:** Gets the component into the render tree with the `+ Add new` path working before any expansion state is involved. This is a testable increment: chips render, alphabetical order works, empty state is OK, `+ Add new` opens ItemModal.
+
+**Files:**
+- Create: `frontend/src/components/QuickAddBar.tsx`
+- Modify: `frontend/src/App.tsx` (import + render)
+- Modify: `frontend/src/App.css` (base chip styles)
+
+- [ ] **Step 1: Create the component file**
+
+Write this full file at `frontend/src/components/QuickAddBar.tsx`:
+
+```tsx
+import { type ItemDefaultsResponse } from "../types/types";
+
+export type QuickAddOverrides = {
+  quantity: number;
+  expirationDate: string;
+};
+
+type QuickAddBarProps = {
+  itemDefaults: ItemDefaultsResponse[];
+  onQuickAdd: (defaults: ItemDefaultsResponse, overrides: QuickAddOverrides) => Promise<void>;
+  onAddNew: () => void;
+};
+
+export default function QuickAddBar({
+  itemDefaults,
+  onAddNew,
+}: QuickAddBarProps) {
+  const sorted = [...itemDefaults].sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <div className="quickaddbar" role="toolbar" aria-label="Quick add">
+      {sorted.map((d) => (
+        <button
+          key={d.name}
+          type="button"
+          className="quickadd-chip"
+        >
+          {d.name}
+        </button>
+      ))}
+      <button
+        type="button"
+        className="quickadd-chip quickadd-add-new"
+        onClick={onAddNew}
+      >
+        + Add new
+      </button>
+    </div>
+  );
+}
+```
+
+`onQuickAdd` is in the props type now (keeps the public contract stable for Task 3) but intentionally unused here — Task 3 wires it up. This avoids a future Props churn.
+
+- [ ] **Step 2: Import and render in `App.tsx`**
+
+Add this import near the existing component imports (roughly `frontend/src/App.tsx:23-35`, wherever you add it preserves alphabetical-ish ordering — no strict rule exists in the file):
+
+```ts
+import QuickAddBar from "./components/QuickAddBar";
+```
+
+Insert the component into the JSX *after* `<FilterBar … />` and *before* the `{foodLoading ? … : …}` block. Current structure is at `frontend/src/App.tsx:289-297` for FilterBar and `:298-312` for the loading/grid block. The insertion point is between line 297 (`</FilterBar>`) and line 298 (`{foodLoading …}`).
+
+Insert:
+
+```tsx
+      <QuickAddBar
+        itemDefaults={itemDefaults}
+        onAddNew={() => setModalState("add")}
+        onQuickAdd={async () => {}}
+      />
+```
+
+`onQuickAdd` is a no-op placeholder for this task. Task 3 replaces it with `handleQuickAdd`.
+
+- [ ] **Step 3: Add base CSS**
+
+Append to `frontend/src/App.css`:
+
+```css
+.quickaddbar {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  background: var(--cream);
+  border-bottom: 1px solid var(--sand-lt);
+}
+
+.quickadd-chip {
+  flex-shrink: 0;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--sand);
+  background: var(--card);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 0.95rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.quickadd-chip:hover {
+  background: var(--tc-pale);
+  border-color: var(--tc-light);
+}
+
+.quickadd-add-new {
+  border-style: dashed;
+  color: var(--mid);
+}
+
+.quickadd-add-new:hover {
+  color: var(--tc);
+}
+```
+
+- [ ] **Step 4: Verify type-check**
+
+Run from `frontend/`:
+```
+npx tsc --noEmit
+```
+Expected: exit 0.
+
+- [ ] **Step 5: Verify Vite build**
+
+```
+npm run build
+```
+Expected: exit 0.
+
+- [ ] **Step 6: Manual smoke test**
+
+Boot the app, log in. Confirm:
+- A bar appears above the food grid with a chip for each of the user's `itemDefaults` (alphabetical) and a trailing `+ Add new` chip.
+- Fresh account / no defaults: the bar shows only `+ Add new`.
+- Clicking a regular chip does nothing (Task 3).
+- Clicking `+ Add new` opens `ItemModal` in empty / add mode.
+- Submitting a new item through the modal closes it and a chip for that name appears in the bar (with correct casing — uppercased by `handleAddedItem`).
+
+- [ ] **Step 7: Commit**
+
+```
+git add frontend/src/components/QuickAddBar.tsx frontend/src/App.tsx frontend/src/App.css
+git commit -m "feat(quickadd): scaffold QuickAddBar with + Add new entry"
+```
+
+---
+
+## Task 3: Add chip expansion, inline form, and `onQuickAdd` submit path
+
+**Why third:** This is the main interaction. Separates cleanly from Task 2's scaffolding. Ends with a functioning quick-add that creates real items.
+
+**Files:**
+- Modify: `frontend/src/components/QuickAddBar.tsx` (expansion state + form + submit wiring)
+- Modify: `frontend/src/App.tsx` (add `handleQuickAdd`, pass it as prop)
+- Modify: `frontend/src/App.css` (expanded-state and form styles)
+
+- [ ] **Step 1: Rewrite `QuickAddBar.tsx` to handle expansion + submit**
+
+Replace the entire file content from Task 2 with:
+
+```tsx
+import { useState } from "react";
+import { type ItemDefaultsResponse } from "../types/types";
+import { todayISO } from "../utility/utils";
+
+export type QuickAddOverrides = {
+  quantity: number;
+  expirationDate: string;
+};
+
+type QuickAddBarProps = {
+  itemDefaults: ItemDefaultsResponse[];
+  onQuickAdd: (
+    defaults: ItemDefaultsResponse,
+    overrides: QuickAddOverrides,
+  ) => Promise<void>;
+  onAddNew: () => void;
+};
+
+export default function QuickAddBar({
+  itemDefaults,
+  onQuickAdd,
+  onAddNew,
+}: QuickAddBarProps) {
+  const [expandedName, setExpandedName] = useState<string | null>(null);
+  const [quantity, setQuantity] = useState(1);
+  const [expirationDate, setExpirationDate] = useState<string>(todayISO());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const sorted = [...itemDefaults].sort((a, b) => a.name.localeCompare(b.name));
+
+  function openChip(d: ItemDefaultsResponse) {
+    if (expandedName === d.name) {
+      setExpandedName(null);
+      return;
+    }
+    const seedDate = new Date();
+    seedDate.setDate(seedDate.getDate() + (d.expirationDays ?? 0));
+    setExpandedName(d.name);
+    setQuantity(1);
+    setExpirationDate(seedDate.toISOString().split("T")[0]);
+  }
+
+  async function confirm(d: ItemDefaultsResponse) {
+    if (isSubmitting || quantity < 1) return;
+    setIsSubmitting(true);
+    try {
+      await onQuickAdd(d, { quantity, expirationDate });
+      setExpandedName(null);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="quickaddbar" role="toolbar" aria-label="Quick add">
+      {sorted.map((d) => {
+        const expanded = expandedName === d.name;
+        return (
+          <div
+            key={d.name}
+            className={
+              expanded ? "quickadd-chip quickadd-chip--expanded" : undefined
+            }
+          >
+            {expanded ? (
+              <form
+                className="quickadd-form"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  confirm(d);
+                }}
+              >
+                <span className="quickadd-form-name">{d.name}</span>
+                <input
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={quantity}
+                  onChange={(e) => setQuantity(Number(e.target.value))}
+                  aria-label="Quantity"
+                />
+                <input
+                  type="date"
+                  value={expirationDate}
+                  onChange={(e) => setExpirationDate(e.target.value)}
+                  aria-label="Expiration date"
+                />
+                <button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? "…" : "Add"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setExpandedName(null)}
+                  disabled={isSubmitting}
+                >
+                  Cancel
+                </button>
+              </form>
+            ) : (
+              <button
+                type="button"
+                className="quickadd-chip"
+                onClick={() => openChip(d)}
+              >
+                {d.name}
+              </button>
+            )}
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        className="quickadd-chip quickadd-add-new"
+        onClick={onAddNew}
+      >
+        + Add new
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add `handleQuickAdd` in `App.tsx`**
+
+Insert this new handler alongside `handleAddedItem` (near `frontend/src/App.tsx:95`, anywhere among the handlers is fine — keep it co-located with `handleAddedItem` for readability):
+
+```ts
+  async function handleQuickAdd(
+    defaults: ItemDefaultsResponse,
+    overrides: QuickAddOverrides,
+  ) {
+    if (!authToken) throw new Error("Not authenticated");
+    const request: FoodItemRequest = {
+      name: defaults.name,
+      foodType: defaults.foodType,
+      unit: defaults.unit,
+      location: defaults.location,
+      quantity: overrides.quantity,
+      purchaseDate: todayISO(),
+      expirationDate: overrides.expirationDate,
+    };
+    const response = await createNewFoodItem(request, authToken, setToken);
+    setFoodList((prev) => [...prev, response]);
+  }
+```
+
+Also add `QuickAddOverrides` to the import from `./components/QuickAddBar`. Change the current import line:
+
+```ts
+import QuickAddBar from "./components/QuickAddBar";
+```
+
+to:
+
+```ts
+import QuickAddBar, { type QuickAddOverrides } from "./components/QuickAddBar";
+```
+
+And `todayISO` should already be imported from `./utility/utils`; verify and add if missing. Check around `frontend/src/App.tsx:27-31`:
+
+```ts
+import {
+  responseToFoodItemRequest,
+  formDataToFoodItemRequest,
+  toggleInSet,
+} from "./utility/utils";
+```
+
+Add `todayISO`:
+
+```ts
+import {
+  responseToFoodItemRequest,
+  formDataToFoodItemRequest,
+  toggleInSet,
+  todayISO,
+} from "./utility/utils";
+```
+
+- [ ] **Step 3: Replace the placeholder `onQuickAdd` prop with the real handler**
+
+Find the JSX where `QuickAddBar` was rendered in Task 2:
+
+```tsx
+      <QuickAddBar
+        itemDefaults={itemDefaults}
+        onAddNew={() => setModalState("add")}
+        onQuickAdd={async () => {}}
+      />
+```
+
+Replace with:
+
+```tsx
+      <QuickAddBar
+        itemDefaults={itemDefaults}
+        onAddNew={() => setModalState("add")}
+        onQuickAdd={handleQuickAdd}
+      />
+```
+
+- [ ] **Step 4: Append expanded-state CSS**
+
+Append to `frontend/src/App.css`:
+
+```css
+.quickadd-chip--expanded {
+  flex-shrink: 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 14px;
+  border: 1px solid var(--tc-light);
+  background: var(--tc-pale);
+}
+
+.quickadd-form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: inherit;
+}
+
+.quickadd-form-name {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.quickadd-form input[type="number"] {
+  width: 4rem;
+}
+
+.quickadd-form input[type="date"] {
+  width: 9rem;
+}
+
+.quickadd-form button {
+  padding: 0.35rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--sand);
+  background: var(--card);
+  color: var(--ink);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.quickadd-form button[type="submit"] {
+  background: var(--tc);
+  color: var(--cream);
+  border-color: var(--tc);
+}
+
+.quickadd-form button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+```
+
+- [ ] **Step 5: Verify type-check**
+
+```
+npx tsc --noEmit
+```
+Expected: exit 0.
+
+- [ ] **Step 6: Verify Vite build**
+
+```
+npm run build
+```
+Expected: exit 0.
+
+- [ ] **Step 7: Manual smoke test**
+
+Boot app, log in. At minimum one `ItemDefault` must exist — add one via ItemModal with a non-zero shelf-life if needed (e.g., Milk, purchase today, expire 7 days out).
+
+Confirm:
+- Tap the `MILK` chip → chip expands inline with qty `1`, expiry pre-filled to 7 days from today.
+- Tap `Add` → new food card appears in the grid; chip collapses.
+- Tap `MILK` again, change expiry to a different date, tap `Add` → food card uses the overridden date. Tap `MILK` a third time → the expansion pre-fills to today+7 again (the stored default was not mutated — as per spec Open Question 1).
+- Tap chip A, then tap chip B without confirming → A collapses and B expands.
+- Tap `Cancel` in the form → collapse, no submit.
+- Tap the same expanded chip again → collapse, no submit.
+- Double-tap `Add` rapidly → only one POST fires (button disabled during `isSubmitting`).
+
+- [ ] **Step 8: Commit**
+
+```
+git add frontend/src/components/QuickAddBar.tsx frontend/src/App.tsx frontend/src/App.css
+git commit -m "feat(quickadd): chip expansion, qty+expiry form, submit path"
+```
+
+---
+
+## Task 4: Collapse on Escape and outside-click
+
+**Why last:** Nice-to-have polish that layers cleanly on top of the expansion state from Task 3. Isolating it keeps Task 3's diff readable.
+
+**Files:**
+- Modify: `frontend/src/components/QuickAddBar.tsx` (add useEffect + ref)
+
+- [ ] **Step 1: Add Escape-key and outside-click handlers**
+
+Change the React import at the top of `QuickAddBar.tsx` from:
+
+```ts
+import { useState } from "react";
+```
+
+to:
+
+```ts
+import { useEffect, useRef, useState } from "react";
+```
+
+Add a ref and effect inside the component, immediately after the four `useState` calls:
+
+```ts
+  const barRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (expandedName === null) return;
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setExpandedName(null);
+    }
+    function handleClick(e: MouseEvent) {
+      if (barRef.current && !barRef.current.contains(e.target as Node)) {
+        setExpandedName(null);
+      }
+    }
+
+    window.addEventListener("keydown", handleKey);
+    window.addEventListener("mousedown", handleClick);
+    return () => {
+      window.removeEventListener("keydown", handleKey);
+      window.removeEventListener("mousedown", handleClick);
+    };
+  }, [expandedName]);
+```
+
+Attach the ref to the outer `<div className="quickaddbar" …>`:
+
+```tsx
+    <div ref={barRef} className="quickaddbar" role="toolbar" aria-label="Quick add">
+```
+
+- [ ] **Step 2: Verify type-check**
+
+```
+npx tsc --noEmit
+```
+Expected: exit 0.
+
+- [ ] **Step 3: Verify Vite build**
+
+```
+npm run build
+```
+Expected: exit 0.
+
+- [ ] **Step 4: Manual smoke test**
+
+Boot app, log in. Expand any chip, then verify each collapse trigger:
+- Press `Escape` → collapses.
+- Click anywhere outside the bar (food grid, header, background) → collapses.
+- Click inside the bar (on another chip or the form) → does not trigger outside-click collapse. Re-tap of the expanded chip still collapses (Task 3 behavior). Clicking a different chip opens that one (Task 3 behavior).
+- Clicking inside the form inputs does NOT collapse (the `<form>` is inside `barRef.current`).
+- After collapse via Escape, `expandedName === null` so the effect's cleanup runs — no stray listeners. Re-expand and verify collapse still works (i.e., effect re-runs on `expandedName` change).
+
+- [ ] **Step 5: Commit**
+
+```
+git add frontend/src/components/QuickAddBar.tsx
+git commit -m "feat(quickadd): collapse on Escape and outside-click"
+```
+
+---
+
+## Verification After All Tasks
+
+Run from `frontend/`:
+
+```
+npx tsc --noEmit
+npm run build
+```
+
+Manual end-to-end check (don't skip — no automated tests cover this):
+
+- [ ] Fresh account: bar shows only `+ Add new`. `+ Add new` opens ItemModal.
+- [ ] Submit new item via ItemModal with non-zero shelf-life → chip appears in bar, `expirationDays` correctly computed.
+- [ ] Quick-add flow end-to-end on a known chip with and without expiry override.
+- [ ] Overriding expiry during quick-add does NOT mutate the stored default.
+- [ ] Collapse interactions: Cancel, Escape, outside-click, re-tap, tap-another-chip.
+- [ ] Mobile-width (≤480px) the bar scrolls horizontally; expanded chip stays legible.
+- [ ] Logout + log back in → bar repopulates from `itemDefaults`.
+- [ ] No regressions: FilterBar, grouping, edit via card, delete via card, SettingsModal all still work.
+
+---
+
+## Notes for the Implementer
+
+- **No test framework.** Do not set one up; the spec explicitly excludes it.
+- **CSS variables.** The palette tokens (`--tc`, `--sage`, `--cream`, `--ink`, `--sand`, `--tc-pale`, `--tc-light`, `--sand-lt`, `--card`, `--mid`) are defined at the top of `frontend/src/App.css`. Use them rather than raw hex colors.
+- **Existing utilities.** `todayISO()` lives in `frontend/src/utility/utils.ts`. Reuse it rather than writing new date helpers.
+- **Don't mutate stored defaults on override.** The spec resolves this explicitly: quick-add is consumption-side only. `handleQuickAdd` must NOT call `setItemDefaults` or post anything to `/user/item-defaults`.
+- **Branch.** Work on `feature/quickaddbar`. Do not merge to master as part of implementation — that's a user action after review.

--- a/docs/superpowers/specs/2026-04-16-quickaddbar-design.md
+++ b/docs/superpowers/specs/2026-04-16-quickaddbar-design.md
@@ -1,0 +1,153 @@
+# QuickAddBar Design Spec
+
+## Goal
+
+Cut friction from two recurring flows that currently require opening the full `ItemModal`:
+- **Batch-add after a grocery trip** (many items, desktop)
+- **Add-one-off when running low** (single item, mobile/tablet)
+
+Known recurring items become one-tap adds with stored-per-name defaults. First-time items keep the existing modal path.
+
+## Approach
+
+A persistent `QuickAddBar` component mounts above the food grid (sibling to `FilterBar`). The bar shows a horizontal strip of **chips**, one per `ItemDefault` row from `/user/item-defaults`, followed by a trailing `+ Add new` chip.
+
+Tapping a chip expands it **inline** — no modal, no popover. The expanded chip reveals a quantity stepper and an expiry date field (pre-filled from the default's `expirationDays`). Confirm creates a `FoodItem`; cancel or Escape collapses back. The `+ Add new` chip opens the existing `ItemModal` for first-time items.
+
+Split-path design: known items take the fast path; new items take the ItemModal path. No hybrid.
+
+## Tech Stack
+
+React 19, TypeScript, existing `fetchFood.ts` API. No new dependencies. Styling via existing CSS variables (terracotta / sage / cream palette, Lora + Source Sans 3).
+
+## Data Model
+
+No backend schema change. `/user/item-defaults` already stores per-name `{ name, foodType, unit, location, expirationDays }`.
+
+One bug fix required as part of this work: `App.tsx:handleAddedItem` currently hardcodes `expirationDays: 0` when appending a new default (line 109). Replace with a computed value: days between `request.purchaseDate` and `request.expirationDate`. Without this fix, every chip expands with today's date as the default expiry and the "shelf-life" feature is inert.
+
+## Components
+
+### New: `QuickAddBar.tsx`
+
+**Location:** `frontend/src/components/QuickAddBar.tsx`
+
+**Props:**
+```ts
+type QuickAddBarProps = {
+  itemDefaults: ItemDefaultsResponse[];
+  onQuickAdd: (defaults: ItemDefaultsResponse, overrides: QuickAddOverrides) => Promise<void>;
+  onAddNew: () => void;
+};
+
+type QuickAddOverrides = {
+  quantity: number;
+  expirationDate: string; // ISO yyyy-mm-dd
+};
+```
+
+**Internal state:** `expandedName: string | null` — at most one chip expanded at a time.
+
+**Rendering:** horizontally-scrollable flex row (`overflow-x: auto`) with chips + trailing `+ Add new`. The expanded chip swaps its label for an inline form (qty stepper, expiry input, confirm/cancel). Other chips remain visible; user can scroll past them.
+
+**Sort:** alphabetical by `name`. Future iterations may add usage-based ordering.
+
+### Modified: `App.tsx`
+
+- Render `<QuickAddBar>` above the grouped `FoodSection`s, below `FilterBar`.
+- New handler `handleQuickAdd(defaults, overrides)` composes a `FoodItemRequest` from defaults + overrides + `purchaseDate = todayISO()`, POSTs via `createNewFoodItem`, and updates `foodList` state.
+- `handleAddedItem` bug fix: compute `expirationDays` from the request's date fields rather than hardcoding 0.
+
+### Modified: `ItemModal.tsx`
+
+No behavioral change. The `+ Add new` button reuses the existing "add" mode entry point (`setModalState("add")`).
+
+### New styles
+
+New CSS classes in `App.css`:
+- `.quickaddbar` — flex container, horizontal scroll
+- `.quickadd-chip` — base chip pill
+- `.quickadd-chip--expanded` — expanded-state styling
+- `.quickadd-form` — inline form inside expanded chip
+- `.quickadd-add-new` — trailing "+ Add new" chip
+
+## User Flows
+
+### A. Quick-add a known item
+1. User sees chip for `MILK`.
+2. Taps chip → chip expands in place. Siblings stay visible.
+3. Qty stepper shows `1`. Expiry shows `today + default.expirationDays`.
+4. User taps Confirm.
+5. `createNewFoodItem` POSTs. Food grid updates with the new card. Chip collapses.
+
+### B. Quick-add with expiry override
+1. Same as A, but user changes the expiry date before confirming.
+2. Food item is created with the overridden date.
+3. **The stored `ItemDefault.expirationDays` is not updated.** Quick-add never mutates stored defaults (see Open Question resolution).
+
+### C. First-time item (no default exists)
+1. User taps `+ Add new` at the end of the bar.
+2. `ItemModal` opens via existing add-mode path.
+3. User fills the full form, submits.
+4. `handleAddedItem` creates the food item AND appends an `ItemDefault` with correctly-computed `expirationDays`.
+5. Next render: a chip for this name appears in the bar.
+
+### D. Cancel expansion
+1. User taps chip, expands.
+2. One of: taps Cancel button inside the form / presses Escape / taps the chip again / taps outside the bar.
+3. Chip collapses. No submit, no state change.
+
+## Edge Cases
+
+- **Empty `itemDefaults` (fresh account):** bar shows only `+ Add new`. No empty-state copy needed — the button is the affordance.
+- **`expirationDays === 0` for a default:** expiry picker pre-fills to today. User may explicitly pick a date. No hiding — the field is always present for consistency.
+- **Quantity constraint:** min 1. Stepper prevents zero/negative. Matches existing `ItemModal` quantity input (`min="0", step="1"` — QuickAddBar uses `min="1"` to avoid accidental zero submits on the fast path).
+- **Name collision with existing filters:** QuickAddBar's source of truth is `itemDefaults`, not `foodList`. Chips appear for names the user has ever added, even if no item currently exists. That's the intended behavior for re-adding a depleted item.
+- **Two chips expanded simultaneously:** prevented by single `expandedName` state; tapping a second chip collapses the first.
+- **Concurrent quick-adds while one is pending:** no optimistic UI. Second tap is ignored while the first is mid-flight (disable confirm button during `isSubmitting`).
+
+## Open Questions (Resolved)
+
+1. **Does expiry-override update stored `expirationDays`?**
+   - **Resolution: No.** Quick-add is consumption-side only. Training the default is explicit — user edits via `ItemModal`. Predictable, avoids silent rewrites from one-off weird expiries.
+
+2. **Sort order of chips.**
+   - **Resolution: Alphabetical by name for MVP.** Frequency/recency ordering deferred. Consistent with how filters in `FilterBar` are displayed.
+
+## Out of Scope (this iteration)
+
+- Bulk-add (multi-select chips, one submit)
+- Autocomplete / typeahead in the bar
+- Chip reordering, favoriting, or removal
+- Editing an `ItemDefault` (name, type, location, etc.) — stays in ItemModal / Settings
+- Mobile-specific gestures (long-press, swipe)
+- Optimistic UI for the food grid on quick-add
+- Analytics / usage tracking for chip taps
+
+## Testing Plan (manual — no frontend test framework)
+
+Run through before merging:
+
+- [ ] Fresh account: bar shows only `+ Add new`. Click it → ItemModal opens.
+- [ ] After first ItemModal submit of "MILK" with expiry 7 days out → chip for `MILK` appears, its expansion pre-fills expiry to today + 7.
+- [ ] Tap `MILK` chip → expand → Confirm → new food card appears, chip collapses.
+- [ ] Tap `MILK` chip → expand → change expiry → Confirm → card uses overridden date; tap chip again → expansion still pre-fills with stored default (override did not persist).
+- [ ] Tap chip → expand → press Escape → collapse, no submit.
+- [ ] Tap chip A → expand → tap chip B → A collapses, B expands.
+- [ ] Many defaults (≥15) → bar scrolls horizontally on mobile width. Expanded chip stays pinned at tap location.
+- [ ] Type-check + Vite build pass.
+- [ ] Visual pass on mobile (375px) and desktop (≥1024px) widths.
+
+## Architecture Summary
+
+```
+App
+├── FilterBar (existing)
+├── QuickAddBar (NEW)
+│   ├── .quickadd-chip × N (one per ItemDefault)
+│   └── .quickadd-add-new (opens ItemModal)
+├── FoodSection × N (existing — one per group)
+└── ItemModal (existing — opens from QuickAddBar's "+ Add new" and from FoodCard click)
+```
+
+No state lifts up from existing components. `QuickAddBar` consumes props; `App` already owns `itemDefaults` and `foodList`.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -452,30 +452,36 @@ button:hover {
 }
 
 .quickaddbar {
+  width: 80%;
+  margin: 0 auto;
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  overflow-x: auto;
-  background: var(--cream);
-  border-bottom: 1px solid var(--sand-lt);
+  padding: 0.75rem 0;
+  font-family: "Source Sans 3", sans-serif;
 }
 
 .quickadd-chip {
   flex-shrink: 0;
   padding: 0.5rem 1rem;
-  border-radius: 999px;
+  border-radius: 24px;
   border: 1px solid var(--sand);
   background: var(--card);
   color: var(--ink);
-  font-family: inherit;
-  font-size: 0.95rem;
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.05rem;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.15s ease, border-color 0.15s ease;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .quickadd-chip:hover {
-  background: var(--tc-pale);
+  background-color: var(--tc-pale);
   border-color: var(--tc-light);
 }
 
@@ -486,50 +492,78 @@ button:hover {
 
 .quickadd-add-new:hover {
   color: var(--tc);
+  background-color: var(--tc-pale);
+  border-color: var(--tc-light);
 }
 
 .quickadd-chip--expanded {
   flex-shrink: 0;
   padding: 0.5rem 0.75rem;
-  border-radius: 14px;
+  border-radius: 16px;
   border: 1px solid var(--tc-light);
-  background: var(--tc-pale);
+  background-color: var(--card);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
 
 .quickadd-form {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-family: inherit;
+  font-family: "Source Sans 3", sans-serif;
 }
 
 .quickadd-form-name {
-  font-weight: 600;
+  font-weight: 500;
+  font-size: 0.85rem;
+  letter-spacing: 0.05rem;
+  color: var(--tc);
+}
+
+.quickadd-form input[type="number"],
+.quickadd-form input[type="date"] {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--sand);
+  border-radius: 8px;
+  background-color: var(--cream);
   color: var(--ink);
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 0.85rem;
 }
 
 .quickadd-form input[type="number"] {
-  width: 4rem;
+  width: 3.5rem;
 }
 
 .quickadd-form input[type="date"] {
-  width: 9rem;
+  width: auto;
+}
+
+.quickadd-form input:focus {
+  outline: none;
+  border-color: var(--tc-light);
 }
 
 .quickadd-form button {
   padding: 0.35rem 0.75rem;
-  border-radius: 8px;
+  border-radius: 24px;
   border: 1px solid var(--sand);
-  background: var(--card);
+  background-color: var(--card);
   color: var(--ink);
   cursor: pointer;
-  font-family: inherit;
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
 }
 
 .quickadd-form button[type="submit"] {
-  background: var(--tc);
-  color: var(--cream);
+  background-color: var(--tc);
+  color: white;
   border-color: var(--tc);
+}
+
+.quickadd-form button[type="submit"]:hover {
+  background-color: var(--tc-light);
+  border-color: var(--tc-light);
 }
 
 .quickadd-form button[disabled] {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -450,3 +450,40 @@ button:hover {
   padding-bottom: 0.5rem;
   border-bottom: 1px solid var(--sand-lt);
 }
+
+.quickaddbar {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  background: var(--cream);
+  border-bottom: 1px solid var(--sand-lt);
+}
+
+.quickadd-chip {
+  flex-shrink: 0;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--sand);
+  background: var(--card);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 0.95rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.quickadd-chip:hover {
+  background: var(--tc-pale);
+  border-color: var(--tc-light);
+}
+
+.quickadd-add-new {
+  border-style: dashed;
+  color: var(--mid);
+}
+
+.quickadd-add-new:hover {
+  color: var(--tc);
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -487,3 +487,52 @@ button:hover {
 .quickadd-add-new:hover {
   color: var(--tc);
 }
+
+.quickadd-chip--expanded {
+  flex-shrink: 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 14px;
+  border: 1px solid var(--tc-light);
+  background: var(--tc-pale);
+}
+
+.quickadd-form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: inherit;
+}
+
+.quickadd-form-name {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.quickadd-form input[type="number"] {
+  width: 4rem;
+}
+
+.quickadd-form input[type="date"] {
+  width: 9rem;
+}
+
+.quickadd-form button {
+  padding: 0.35rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--sand);
+  background: var(--card);
+  color: var(--ink);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.quickadd-form button[type="submit"] {
+  background: var(--tc);
+  color: var(--cream);
+  border-color: var(--tc);
+}
+
+.quickadd-form button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,12 +101,20 @@ function App() {
       authToken,
       setToken,
     );
+    const expirationDays = Math.max(
+      0,
+      Math.round(
+        (new Date(request.expirationDate).getTime() -
+          new Date(request.purchaseDate).getTime()) /
+          (1000 * 60 * 60 * 24),
+      ),
+    );
     const defaults: ItemDefaultsResponse = {
       name: request.name.toUpperCase(),
       foodType: request.foodType.toUpperCase(),
       unit: request.unit.toUpperCase(),
       location: request.location.toUpperCase(),
-      expirationDays: 0,
+      expirationDays,
     };
     setItemDefaults((prev) => [...prev, defaults]);
     setFoodList((prev) => [...prev, response]);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ import {
   getItemDefaults,
 } from "./api/fetchFood";
 import ItemModal from "./components/ItemModal";
-import QuickAddBar from "./components/QuickAddBar";
+import QuickAddBar, { type QuickAddOverrides } from "./components/QuickAddBar";
 import AuthenticationModal from "./components/AuthCard";
 import FilterBar from "./components/FilterBar";
 import NavBar from "./components/NavBar";
@@ -29,6 +29,7 @@ import {
   responseToFoodItemRequest,
   formDataToFoodItemRequest,
   toggleInSet,
+  todayISO,
 } from "./utility/utils";
 
 import "./App.css";
@@ -120,6 +121,24 @@ function App() {
     setItemDefaults((prev) => [...prev, defaults]);
     setFoodList((prev) => [...prev, response]);
     setModalState(null);
+  }
+
+  async function handleQuickAdd(
+    defaults: ItemDefaultsResponse,
+    overrides: QuickAddOverrides,
+  ) {
+    if (!authToken) throw new Error("Not authenticated");
+    const request: FoodItemRequest = {
+      name: defaults.name,
+      foodType: defaults.foodType,
+      unit: defaults.unit as FoodItemRequest["unit"],
+      location: defaults.location,
+      quantity: overrides.quantity,
+      purchaseDate: todayISO(),
+      expirationDate: overrides.expirationDate,
+    };
+    const response = await createNewFoodItem(request, authToken, setToken);
+    setFoodList((prev) => [...prev, response]);
   }
 
   async function handleLogout() {
@@ -307,7 +326,7 @@ function App() {
       <QuickAddBar
         itemDefaults={itemDefaults}
         onAddNew={() => setModalState("add")}
-        onQuickAdd={async () => {}}
+        onQuickAdd={handleQuickAdd}
       />
       {foodLoading ? (
         <div>Loading...</div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import {
   getItemDefaults,
 } from "./api/fetchFood";
 import ItemModal from "./components/ItemModal";
+import QuickAddBar from "./components/QuickAddBar";
 import AuthenticationModal from "./components/AuthCard";
 import FilterBar from "./components/FilterBar";
 import NavBar from "./components/NavBar";
@@ -303,6 +304,11 @@ function App() {
         setLocationFilter={locationFilterHandler}
         setGroupBy={setGroupBy}
       ></FilterBar>
+      <QuickAddBar
+        itemDefaults={itemDefaults}
+        onAddNew={() => setModalState("add")}
+        onQuickAdd={async () => {}}
+      />
       {foodLoading ? (
         <div>Loading...</div>
       ) : (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -105,14 +105,16 @@ function App() {
       authToken,
       setToken,
     );
-    const expirationDays = Math.max(
-      0,
-      Math.round(
-        (new Date(request.expirationDate).getTime() -
-          new Date(request.purchaseDate).getTime()) /
-          (1000 * 60 * 60 * 24),
-      ),
-    );
+    const expirationDays = request.expirationDate
+      ? Math.max(
+          0,
+          Math.round(
+            (new Date(request.expirationDate).getTime() -
+              new Date(request.purchaseDate).getTime()) /
+              (1000 * 60 * 60 * 24),
+          ),
+        )
+      : 0;
     const defaults: ItemDefaultsResponse = {
       name: request.name.toUpperCase(),
       foodType: request.foodType.toUpperCase(),

--- a/frontend/src/components/QuickAddBar.tsx
+++ b/frontend/src/components/QuickAddBar.tsx
@@ -81,7 +81,7 @@ export default function QuickAddBar({
           <div
             key={d.name}
             className={
-              expanded ? "quickadd-chip quickadd-chip--expanded" : undefined
+              expanded ? "quickadd-chip--expanded" : undefined
             }
           >
             {expanded ? (

--- a/frontend/src/components/QuickAddBar.tsx
+++ b/frontend/src/components/QuickAddBar.tsx
@@ -1,0 +1,40 @@
+import { type ItemDefaultsResponse } from "../types/types";
+
+export type QuickAddOverrides = {
+  quantity: number;
+  expirationDate: string;
+};
+
+type QuickAddBarProps = {
+  itemDefaults: ItemDefaultsResponse[];
+  onQuickAdd: (defaults: ItemDefaultsResponse, overrides: QuickAddOverrides) => Promise<void>;
+  onAddNew: () => void;
+};
+
+export default function QuickAddBar({
+  itemDefaults,
+  onAddNew,
+}: QuickAddBarProps) {
+  const sorted = [...itemDefaults].sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <div className="quickaddbar" role="toolbar" aria-label="Quick add">
+      {sorted.map((d) => (
+        <button
+          key={d.name}
+          type="button"
+          className="quickadd-chip"
+        >
+          {d.name}
+        </button>
+      ))}
+      <button
+        type="button"
+        className="quickadd-chip quickadd-add-new"
+        onClick={onAddNew}
+      >
+        + Add new
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/QuickAddBar.tsx
+++ b/frontend/src/components/QuickAddBar.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { type ItemDefaultsResponse } from "../types/types";
+import { todayISO } from "../utility/utils";
 
 export type QuickAddOverrides = {
   quantity: number;
@@ -7,27 +9,105 @@ export type QuickAddOverrides = {
 
 type QuickAddBarProps = {
   itemDefaults: ItemDefaultsResponse[];
-  onQuickAdd: (defaults: ItemDefaultsResponse, overrides: QuickAddOverrides) => Promise<void>;
+  onQuickAdd: (
+    defaults: ItemDefaultsResponse,
+    overrides: QuickAddOverrides,
+  ) => Promise<void>;
   onAddNew: () => void;
 };
 
 export default function QuickAddBar({
   itemDefaults,
+  onQuickAdd,
   onAddNew,
 }: QuickAddBarProps) {
+  const [expandedName, setExpandedName] = useState<string | null>(null);
+  const [quantity, setQuantity] = useState(1);
+  const [expirationDate, setExpirationDate] = useState<string>(todayISO());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const sorted = [...itemDefaults].sort((a, b) => a.name.localeCompare(b.name));
+
+  function openChip(d: ItemDefaultsResponse) {
+    if (expandedName === d.name) {
+      setExpandedName(null);
+      return;
+    }
+    const seedDate = new Date();
+    seedDate.setDate(seedDate.getDate() + (d.expirationDays ?? 0));
+    setExpandedName(d.name);
+    setQuantity(1);
+    setExpirationDate(seedDate.toISOString().split("T")[0]);
+  }
+
+  async function confirm(d: ItemDefaultsResponse) {
+    if (isSubmitting || quantity < 1) return;
+    setIsSubmitting(true);
+    try {
+      await onQuickAdd(d, { quantity, expirationDate });
+      setExpandedName(null);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
 
   return (
     <div className="quickaddbar" role="toolbar" aria-label="Quick add">
-      {sorted.map((d) => (
-        <button
-          key={d.name}
-          type="button"
-          className="quickadd-chip"
-        >
-          {d.name}
-        </button>
-      ))}
+      {sorted.map((d) => {
+        const expanded = expandedName === d.name;
+        return (
+          <div
+            key={d.name}
+            className={
+              expanded ? "quickadd-chip quickadd-chip--expanded" : undefined
+            }
+          >
+            {expanded ? (
+              <form
+                className="quickadd-form"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  confirm(d);
+                }}
+              >
+                <span className="quickadd-form-name">{d.name}</span>
+                <input
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={quantity}
+                  onChange={(e) => setQuantity(Number(e.target.value))}
+                  aria-label="Quantity"
+                />
+                <input
+                  type="date"
+                  value={expirationDate}
+                  onChange={(e) => setExpirationDate(e.target.value)}
+                  aria-label="Expiration date"
+                />
+                <button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? "…" : "Add"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setExpandedName(null)}
+                  disabled={isSubmitting}
+                >
+                  Cancel
+                </button>
+              </form>
+            ) : (
+              <button
+                type="button"
+                className="quickadd-chip"
+                onClick={() => openChip(d)}
+              >
+                {d.name}
+              </button>
+            )}
+          </div>
+        );
+      })}
       <button
         type="button"
         className="quickadd-chip quickadd-add-new"

--- a/frontend/src/components/QuickAddBar.tsx
+++ b/frontend/src/components/QuickAddBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { type ItemDefaultsResponse } from "../types/types";
 import { todayISO } from "../utility/utils";
 
@@ -26,6 +26,28 @@ export default function QuickAddBar({
   const [expirationDate, setExpirationDate] = useState<string>(todayISO());
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const barRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (expandedName === null) return;
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setExpandedName(null);
+    }
+    function handleClick(e: MouseEvent) {
+      if (barRef.current && !barRef.current.contains(e.target as Node)) {
+        setExpandedName(null);
+      }
+    }
+
+    window.addEventListener("keydown", handleKey);
+    window.addEventListener("mousedown", handleClick);
+    return () => {
+      window.removeEventListener("keydown", handleKey);
+      window.removeEventListener("mousedown", handleClick);
+    };
+  }, [expandedName]);
+
   const sorted = [...itemDefaults].sort((a, b) => a.name.localeCompare(b.name));
 
   function openChip(d: ItemDefaultsResponse) {
@@ -52,7 +74,7 @@ export default function QuickAddBar({
   }
 
   return (
-    <div className="quickaddbar" role="toolbar" aria-label="Quick add">
+    <div ref={barRef} className="quickaddbar" role="toolbar" aria-label="Quick add">
       {sorted.map((d) => {
         const expanded = expandedName === d.name;
         return (


### PR DESCRIPTION
## Summary
- Adds a persistent `QuickAddBar` above the food grid with one chip per stored `ItemDefault`
- Tapping a chip expands inline with qty stepper + expiry date picker; confirm POSTs a new food item
- `+ Add new` chip opens the existing `ItemModal` for first-time items
- Fixes `handleAddedItem` bug that hardcoded `expirationDays: 0` instead of computing from request dates
- Escape key and outside-click collapse the expanded chip

## Test plan
- [ ] Fresh account: bar shows only `+ Add new`, clicking opens ItemModal
- [ ] After ItemModal submit with 7-day shelf life, chip appears with correct expiry pre-fill
- [ ] Quick-add end-to-end: tap chip, confirm, food card appears
- [ ] Expiry override does NOT persist to stored default
- [ ] Collapse: Cancel, Escape, outside-click, re-tap, tap-another-chip
- [ ] Mobile width: chips wrap, expanded form stays legible
- [ ] No regressions: FilterBar, grouping, edit/delete, SettingsModal

🤖 Generated with [Claude Code](https://claude.com/claude-code)