### PR TITLE
Frontend design overhaul + responsive mobile/tablet layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1395,3 +1395,216 @@ button:hover {
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+/* ── Responsive: tablet portrait ── */
+@media (max-width: 960px) {
+  .navbar {
+    padding: 0.85rem 5%;
+  }
+  .filterbar,
+  .food-section,
+  .error-banner,
+  .quickaddbar {
+    width: 92%;
+  }
+  .empty-state {
+    width: 92%;
+  }
+  .foodlist {
+    gap: 1.5rem;
+  }
+}
+
+/* ── Responsive: phone ── */
+@media (max-width: 640px) {
+  .navbar {
+    padding: 0.7rem 1rem;
+    margin-bottom: 1rem;
+  }
+  .navbar-title {
+    font-size: 1.2rem;
+  }
+  .navbar-mark {
+    width: 30px;
+    height: 30px;
+  }
+  .navbar-actions {
+    gap: 0.35rem;
+  }
+  .navbar-actions button {
+    font-size: 0.82rem;
+    padding: 0.5rem 0.8rem;
+  }
+  .navbar-add {
+    padding: 0.5rem 0.85rem;
+  }
+  .navbar-ghost span {
+    display: none;
+  }
+  .navbar-ghost {
+    padding: 0.5rem 0.65rem;
+  }
+
+  .filterbar {
+    width: calc(100% - 2rem);
+    margin: 1rem auto;
+  }
+  .filterrow {
+    padding: 0.25rem 0;
+  }
+  .filterrow > span {
+    flex-basis: 100%;
+    width: auto;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 0.1rem;
+  }
+  .filterrow button {
+    padding: 0.48rem 0.85rem;
+    font-size: 0.82rem;
+    min-height: 36px;
+  }
+  .filterrow select {
+    padding: 0.5rem 0.85rem;
+    font-size: 0.85rem;
+    min-height: 36px;
+  }
+  .filterrow .filter-clear {
+    min-height: 0;
+  }
+
+  .quickaddbar {
+    width: calc(100% - 2rem);
+    margin: 0.5rem auto;
+    padding: 0.5rem 0;
+  }
+  .quickadd-chip {
+    padding: 0.55rem 1rem;
+    min-height: 38px;
+  }
+  .quickadd-form input[type="number"],
+  .quickadd-form input[type="date"],
+  .quickadd-form button {
+    min-height: 36px;
+  }
+
+  .foodlist {
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+  }
+  .food-section {
+    width: calc(100% - 2rem);
+    margin: 0 auto 2rem;
+  }
+  .food-section-header {
+    margin-bottom: 0.75rem;
+  }
+  .foodcard {
+    padding: 1rem 1.15rem;
+    gap: 0.75rem;
+  }
+  .itemName {
+    font-size: 1.25rem;
+  }
+  .number {
+    font-size: 1.2rem;
+  }
+
+  .error-banner {
+    width: calc(100% - 2rem);
+    margin: 0 auto 1rem;
+    font-size: 0.85rem;
+  }
+
+  .empty-state {
+    width: calc(100% - 2rem);
+    margin: 2rem auto;
+    padding: 2rem 1.25rem;
+  }
+  .empty-state-mark {
+    width: 60px;
+    height: 60px;
+  }
+  .empty-state-title {
+    font-size: 1.2rem;
+  }
+
+  /* Modals: stay centered but give content room + internal scroll */
+  .overlay {
+    padding: 1rem;
+  }
+  .modalcard {
+    max-width: none;
+    padding: 1.5rem 1.25rem 1.25rem;
+    max-height: calc(100vh - 2rem);
+    overflow-y: auto;
+  }
+  .modal-close {
+    top: 0.85rem;
+    right: 0.85rem;
+  }
+  .formrow {
+    flex-direction: column;
+    gap: 0;
+  }
+  .modal-submit {
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+  }
+
+  .authcard {
+    max-width: none;
+    width: 100%;
+    padding: 2.25rem 1.5rem 1.75rem;
+  }
+  .authcard::before {
+    left: 1.5rem;
+    right: 1.5rem;
+  }
+  .auth-title {
+    font-size: 1.85rem;
+  }
+
+  .settings-add input {
+    min-height: 38px;
+  }
+  .settings-add button {
+    min-height: 38px;
+  }
+  .settings-item {
+    font-size: 0.9rem;
+  }
+  .settings-item button {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
+/* ── Touch-primary devices: always reveal delete, kill stuck hover states ── */
+@media (hover: none) {
+  .deleteitem {
+    opacity: 1;
+    transform: scale(1);
+  }
+  .foodcard:hover {
+    transform: none;
+    box-shadow: none;
+    border-color: var(--sand-lt);
+  }
+  .foodcard:active {
+    transform: scale(0.995);
+    box-shadow: 0 2px 6px rgba(44, 24, 16, 0.06);
+  }
+  .filterrow button:hover,
+  .navbar-actions button:hover,
+  .empty-state-cta:hover,
+  .modal-submit:hover,
+  .auth-submit:hover {
+    background-color: inherit;
+    box-shadow: none;
+  }
+  .filterrow button.selected:hover {
+    background-color: var(--tc);
+  }
+}


### PR DESCRIPTION
## Summary
Supersedes #37. Combines the full warm-earth design overhaul with a responsive mobile/tablet layer on top.

## Commits (7)
**Design overhaul (originally PR #37):**
- `9d6d794` — filters, food card, item modal, settings
- `9652a2d` — NavBar + AuthCard
- `40cc7cf` — empty states, skeleton loader, group headers
- `df1a9de` — FoodCard expiration urgency indicators
- `8228284` — hoist expiry tag into FoodCard badge row
- `8bb8e51` — drop dead `.cardfooter` CSS

**Mobile layout (new):**
- `7d3d7f4` — responsive mobile + tablet breakpoints, touch affordances

## Responsive behavior
- **≤960px** (tablet portrait): 80%-locked containers widen to 92%, navbar padding eases
- **≤640px** (phone): filter labels stack above wrapped pills, food grid collapses to 1 col, modal near-fullwidth with internal scroll, auth card breathes
- **`hover: none`** (touch): delete button always visible, hover lift disabled, `:active` press feedback

## Test plan
- [ ] Desktop: layout unchanged at ≥961px
- [ ] Tablet portrait (~768px): nav + filter bar + grid feel natural, no cramped elements
- [ ] Phone (~375-414px): single column cards, filter pills wrap cleanly, modal usable
- [ ] Touch: tap card → edit modal, delete visible without hover, no stuck hover states

🤖 Generated with [Claude Code](https://claude.com/claude-code)